### PR TITLE
Fix implicit declaration of memset and exit

### DIFF
--- a/common/mktmptbl.c
+++ b/common/mktmptbl.c
@@ -43,6 +43,7 @@
 static char RCSID[]="$Id: mktmptbl.c,v 1.9 2002/11/02 15:12:06 lucifer Exp $";
 
 #include <stdio.h>
+#include <string.h>
 #include "mktmptbl.h"
 
 ushort	tempTable[256][64];

--- a/makekey/makekey.c
+++ b/makekey/makekey.c
@@ -12,6 +12,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include "pkcrack.h"
 #include "keystuff.h"
 #include "crc.h"


### PR DESCRIPTION
The code does not compile on macOS using latest Xcode due to missing includes